### PR TITLE
Language fix in test-classes.

### DIFF
--- a/exomiser-core/src/main/java/de/charite/compbio/exomiser/core/filter/FilterReportFactory.java
+++ b/exomiser-core/src/main/java/de/charite/compbio/exomiser/core/filter/FilterReportFactory.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.Locale;
 
 /**
  * Factory class for producing {@code FilterReport} lists from the list of
@@ -22,6 +23,7 @@ import org.slf4j.LoggerFactory;
  * @author Jules Jacobsen <jules.jacobsen@sanger.ac.uk>
  */
 public class FilterReportFactory {
+	
 
     private static final Logger logger = LoggerFactory.getLogger(FilterReportFactory.class);
 

--- a/exomiser-core/src/test/java/de/charite/compbio/exomiser/core/filter/FilterReportFactoryTest.java
+++ b/exomiser-core/src/test/java/de/charite/compbio/exomiser/core/filter/FilterReportFactoryTest.java
@@ -16,12 +16,16 @@ import de.charite.compbio.exomiser.core.model.VariantEvaluation;
 import de.charite.compbio.exomiser.priority.PriorityType;
 import jannovar.common.ModeOfInheritance;
 import jannovar.exome.Variant;
+
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.*;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -165,6 +169,8 @@ public class FilterReportFactoryTest {
     
     @Test
     public void testMakeFrequencyFilterReportProducesCorrectStatistics() {
+    	// set locale to English. Otherwise test (and others) will fail for example on German computers.
+    	Locale.setDefault(Locale.ENGLISH);
         FilterType filterType = FilterType.FREQUENCY_FILTER;
 
         VariantEvaluation completelyNovelVariantEval = makePassedFilterVariantEvaluation(filterType);


### PR DESCRIPTION
Set Locale to English, Otherwise test will fail on German computers because "," is used instead of "."

mvn package etc. will fail too.