### PR TITLE
Test cases for InheritanceModeFilter.

### DIFF
--- a/exomiser-core/src/test/java/de/charite/compbio/exomiser/core/AnalysisRunnerTestBase.java
+++ b/exomiser-core/src/test/java/de/charite/compbio/exomiser/core/AnalysisRunnerTestBase.java
@@ -35,6 +35,10 @@ public abstract class AnalysisRunnerTestBase {
     private static final Logger logger = LoggerFactory.getLogger(AnalysisRunnerTestBase.class);
  
     final Path vcfPath = Paths.get("src/test/resources/smallTest.vcf");
+    
+    final Path twoAffectedPedPATH = Paths.get("src/test/resources/inheritance/twoAffected.ped");
+    final Path childAffectedPedPATH = Paths.get("src/test/resources/inheritance/childAffected.ped");
+    final Path inheritanceFilterVCFPath = Paths.get("src/test/resources/inheritance/inheritanceFilterTest.vcf");
 
     final JannovarData testJannovarData = new TestJannovarDataFactory().getJannovarData();
     final VariantContextAnnotator variantContextAnnotator = new VariantContextAnnotator(testJannovarData.getRefDict(), testJannovarData.getChromosomes());

--- a/exomiser-core/src/test/resources/inheritance/childAffected.ped
+++ b/exomiser-core/src/test/resources/inheritance/childAffected.ped
@@ -1,0 +1,3 @@
+1	Eva	0	0	2	1
+1	Adam	0	0	1	1
+1	Seth	Adam	Eva	1	2

--- a/exomiser-core/src/test/resources/inheritance/inheritanceFilterTest.vcf
+++ b/exomiser-core/src/test/resources/inheritance/inheritanceFilterTest.vcf
@@ -1,0 +1,14 @@
+##fileformat=VCFv4.1
+##Another comment line.
+##description=This file contains a few variants for inheritance testing. 
+##description=The gene RBM8A matches AUTOSOMAL_DOMINANT (trio, child+father affected, chr1:123256213 -> het affected HOM_REF unaffected) and AUTOSOMAL_RECESSIVE (trio, child affected, chr1:145508800 + chr1:123256213 -> compoundHet)
+##description=The gene GNRHR2 matches AUTOSOMAL_DOMINANT (trio, child affected, chr1:145510000 deNovo)
+##description=The gene FGFR2 matches AUTOSOMAL_RECESSIVE (trio, child affected, chr1:123239370 HOM_Alt child and HET parents)
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Seth	Adam	Eva
+1	123256213	.	CA	CC	100.15	PASS	GENE=RBM8A	GT:DP	0/1:33	0/1:33	0/0:33
+1	145508701	.	T	C	123.15	PASS	GENE=RBM8A	GT:DP	1/1:21	1/1:33	1/1:33
+1	145508800	rs12345678	T	C	123.15	PASS	GENE=RBM8A	GT:DP	0/1:21	0/0:33	1/0:33
+1	145510000	rs23456789	G	A	260.15	PASS	GENE=GNRHR2	GT:DP	0/1:21	0/0:33	0/0:33
+1	145510001	.	G	A	260.15	PASS	GENE=GNRHR2	GT:DP	0/1:21	0/1:33	0/1:33
+10	123357972	.	G	A	260.15	PASS	GENE=FGFR2	GT:DP	1/1:21	0/1:33	0/0:33
+10	123239370	.	G	A	260.15	PASS	GENE=FGFR2	GT:DP	1/1:21	0/1:33	0/1:33

--- a/exomiser-core/src/test/resources/inheritance/twoAffected.ped
+++ b/exomiser-core/src/test/resources/inheritance/twoAffected.ped
@@ -1,0 +1,3 @@
+1	Eva	0	0	2	1
+1	Adam	0	0	1	2
+1	Seth	Adam	Eva	1	2


### PR DESCRIPTION
Tests for AD and AR are implemented

They will fail, because variants that did not fit to the given
inheritance will not removed in the PASS_ONLY mode. This has to be fixed.
