### PR TITLE
HikariCP update to 2.4.3 (java6 is not supported)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,8 @@
         https://github.com/brettwooldridge/HikariCP -->
         <dependency>
             <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP-java6</artifactId>
-            <version>2.2.5</version>
+            <artifactId>HikariCP</artifactId>
+            <version>2.4.3</version>
             <scope>compile</scope>
         </dependency>
         <!--Ehcache for caching-->


### PR DESCRIPTION
fixes my problems with eclipse (but I think this can be updated globally)
