### PR TITLE
Rename MNCDS to ReMM_SCORE in output

### DIFF
--- a/exomiser-core/src/main/java/de/charite/compbio/exomiser/core/writers/TsvVariantResultsWriter.java
+++ b/exomiser-core/src/main/java/de/charite/compbio/exomiser/core/writers/TsvVariantResultsWriter.java
@@ -74,7 +74,7 @@ public class TsvVariantResultsWriter implements ResultsWriter {
             .withRecordSeparator("\n")
             .withIgnoreSurroundingSpaces(true)
             .withHeader("#CHROM", "POS", "REF", "ALT", "QUAL", "FILTER", "GENOTYPE", "COVERAGE", "FUNCTIONAL_CLASS", "HGVS", "EXOMISER_GENE",
-                    "CADD(>0.483)", "POLYPHEN(>0.956|>0.446)", "MUTATIONTASTER(>0.94)", "SIFT(<0.06)", "ReMM_SCORE",
+                    "CADD(>0.483)", "POLYPHEN(>0.956|>0.446)", "MUTATIONTASTER(>0.94)", "SIFT(<0.06)", "REMM",
                     "DBSNP_ID", "MAX_FREQUENCY", "DBSNP_FREQUENCY", "EVS_EA_FREQUENCY", "EVS_AA_FREQUENCY",
                     "EXAC_AFR_FREQ", "EXAC_AMR_FREQ", "EXAC_EAS_FREQ", "EXAC_FIN_FREQ", "EXAC_NFE_FREQ", "EXAC_SAS_FREQ", "EXAC_OTH_FREQ",
                     "EXOMISER_VARIANT_SCORE", "EXOMISER_GENE_PHENO_SCORE", "EXOMISER_GENE_VARIANT_SCORE", "EXOMISER_GENE_COMBINED_SCORE");

--- a/exomiser-core/src/test/java/de/charite/compbio/exomiser/core/writers/TsvVariantResultsWriterTest.java
+++ b/exomiser-core/src/test/java/de/charite/compbio/exomiser/core/writers/TsvVariantResultsWriterTest.java
@@ -40,7 +40,7 @@ public class TsvVariantResultsWriterTest {
     private TsvVariantResultsWriter instance;
     
     private static final String VARIANT_DETAILS_HEADER = "#CHROM\tPOS\tREF\tALT\tQUAL\tFILTER\tGENOTYPE\tCOVERAGE\tFUNCTIONAL_CLASS\tHGVS\tEXOMISER_GENE\t";
-    private static final String PATHOGENICITY_SCORES_HEADER = "CADD(>0.483)\tPOLYPHEN(>0.956|>0.446)\tMUTATIONTASTER(>0.94)\tSIFT(<0.06)\tReMM_SCORE\t";
+    private static final String PATHOGENICITY_SCORES_HEADER = "CADD(>0.483)\tPOLYPHEN(>0.956|>0.446)\tMUTATIONTASTER(>0.94)\tSIFT(<0.06)\tREMM\t";
     private static final String FREQUENCY_DATA_HEADER =  "DBSNP_ID\tMAX_FREQUENCY\tDBSNP_FREQUENCY\t"
             + "EVS_EA_FREQUENCY\tEVS_AA_FREQUENCY\t"
             + "EXAC_AFR_FREQ\tEXAC_AMR_FREQ\tEXAC_EAS_FREQ\tEXAC_FIN_FREQ\tEXAC_NFE_FREQ\tEXAC_SAS_FREQ\tEXAC_OTH_FREQ\t";


### PR DESCRIPTION
The remm-score is named MNCDS in the output. This pull request fixes this minor "bug".
