### PR TITLE
WIP: Making PhenixPriotizer use Ontolib instead of Ontologizer

### DIFF
--- a/exomiser-cli/src/main/java/org/monarchinitiative/exomiser/cli/options/PrioritiserOptionMarshaller.java
+++ b/exomiser-cli/src/main/java/org/monarchinitiative/exomiser/cli/options/PrioritiserOptionMarshaller.java
@@ -48,7 +48,7 @@ public class PrioritiserOptionMarshaller extends AbstractOptionMarshaller {
     public PrioritiserOptionMarshaller() {
 
         prioritiserCliValues.put("hiphive", PriorityType.HIPHIVE_PRIORITY);
-        prioritiserCliValues.put("phenix", PriorityType.PHENIX_PRIORITY);
+        prioritiserCliValues.put("legacy-phenix", PriorityType.LEGACY_PHENIX_PRIORITY);
         prioritiserCliValues.put("phive", PriorityType.PHIVE_PRIORITY);
         prioritiserCliValues.put("exomewalker", PriorityType.EXOMEWALKER_PRIORITY);
         prioritiserCliValues.put("omim", PriorityType.OMIM_PRIORITY);

--- a/exomiser-cli/src/test/java/org/monarchinitiative/exomiser/cli/options/PrioritiserOptionMarshallerTest.java
+++ b/exomiser-cli/src/test/java/org/monarchinitiative/exomiser/cli/options/PrioritiserOptionMarshallerTest.java
@@ -82,9 +82,9 @@ public class PrioritiserOptionMarshallerTest {
     }
           
     @Test
-    public void testApplyValuesToSettingsBuilder_phenix() {
-        Settings settings = applyValueAndBuildSettings("phenix");
-        assertThat(settings.getPrioritiserType(), equalTo(PriorityType.PHENIX_PRIORITY));
+    public void testApplyValuesToSettingsBuilder_legacy_phenix() {
+        Settings settings = applyValueAndBuildSettings("legacy-phenix");
+        assertThat(settings.getPrioritiserType(), equalTo(PriorityType.LEGACY_PHENIX_PRIORITY));
     }
     
     @Test

--- a/exomiser-core/pom.xml
+++ b/exomiser-core/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>jblas</artifactId>
             <version>1.2.3</version>
         </dependency>
-        <!--Phenix dependencies:-->
+        <!--LegacyPhenix dependencies:-->
         <dependency>
             <groupId>de.sonumina</groupId>
             <artifactId>javautil</artifactId>

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/analysis/AnalysisBuilder.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/analysis/AnalysisBuilder.java
@@ -229,7 +229,7 @@ public class AnalysisBuilder {
     }
 
     public AnalysisBuilder addPhenixPrioritiser() {
-        addPrioritiserStepIfHpoIdsNotEmpty(priorityFactory.makePhenixPrioritiser());
+        addPrioritiserStepIfHpoIdsNotEmpty(priorityFactory.makeLegacyPhenixPrioritiser());
         return this;
     }
 

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/analysis/AnalysisParser.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/analysis/AnalysisParser.java
@@ -341,7 +341,7 @@ public class AnalysisParser {
                 case "phivePrioritiser":
                     return prioritiserFactory.makePhivePrioritiser();
                 case "phenixPrioritiser":
-                    return prioritiserFactory.makePhenixPrioritiser();
+                    return prioritiserFactory.makeLegacyPhenixPrioritiser();
                 case "exomeWalkerPrioritiser":
                     return makeWalkerPrioritiser(analysisStepMap);
                 default:

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/analysis/util/RawScoreGeneScorer.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/analysis/util/RawScoreGeneScorer.java
@@ -162,7 +162,7 @@ public class RawScoreGeneScorer implements GeneScorer {
             //NB this is based on raw walker score
             double logitScore = 1 / (1 + Math.exp(-(-8.67972 + 219.40082 * priorityScore + 8.54374 * filterScore)));
             return (float) logitScore;
-        } else if (prioritiesRun.contains(PriorityType.PHENIX_PRIORITY)) {
+        } else if (prioritiesRun.contains(PriorityType.LEGACY_PHENIX_PRIORITY)) {
             double logitScore = 1 / (1 + Math.exp(-(-11.15659 + 13.21835 * priorityScore + 4.08667 * filterScore)));
             return (float) logitScore;
         } else {

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/LegacyPhenixPriority.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/LegacyPhenixPriority.java
@@ -56,11 +56,11 @@ import static java.util.stream.Collectors.toMap;
  * @author Sebastian Köhler <dr.sebastian.koehler@gmail.com>
  * @version 0.06 (6 December, 2013)
  */
-public class PhenixPriority implements Prioritiser {
+public class LegacyPhenixPriority implements Prioritiser {
 
-    private static final Logger logger = LoggerFactory.getLogger(PhenixPriority.class);
+    private static final Logger logger = LoggerFactory.getLogger(LegacyPhenixPriority.class);
 
-    private static final PriorityType PRIORITY_TYPE = PriorityType.PHENIX_PRIORITY;
+    private static final PriorityType PRIORITY_TYPE = PriorityType.LEGACY_PHENIX_PRIORITY;
     /**
      * The HPO as Ontologizer-Ontology object
      */
@@ -113,7 +113,7 @@ public class PhenixPriority implements Prioritiser {
      * @see <a href="http://purl.obolibrary.org/obo/hp/uberpheno/">Uberpheno
      * Hudson page</a>
      */
-    public PhenixPriority(String scoreDistributionFolder, boolean symmetric) {
+    public LegacyPhenixPriority(String scoreDistributionFolder, boolean symmetric) {
 
         if (!scoreDistributionFolder.endsWith(File.separator)) {
             scoreDistributionFolder += File.separator;
@@ -136,7 +136,7 @@ public class PhenixPriority implements Prioritiser {
      * STUB CONSTRUCTOR - ONLY USED FOR TESTING PURPOSES TO AVOID NULL POINTERS FROM ORIGINAL CONSTRUCTOR. DO NOT USE FOR PRODUCTION CODE!!!!
      * @param symmetric
      */
-    protected PhenixPriority(boolean symmetric) {
+    protected LegacyPhenixPriority(boolean symmetric) {
         this.symmetric = symmetric;
     }
 
@@ -385,13 +385,13 @@ public class PhenixPriority implements Prioritiser {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        PhenixPriority that = (PhenixPriority) o;
+        LegacyPhenixPriority that = (LegacyPhenixPriority) o;
         return symmetric == that.symmetric;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(PhenixPriority.class.getName(), symmetric);
+        return Objects.hash(LegacyPhenixPriority.class.getName(), symmetric);
     }
 
     @Override

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/PhenixPriorityResult.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/PhenixPriorityResult.java
@@ -41,7 +41,7 @@ public class PhenixPriorityResult extends AbstractPriorityResult {
     private final double negativeLogP;
 
     public PhenixPriorityResult(int geneId, String geneSymbol, double score, double semanticSimilarityScore, double negLogP) {
-        super(PriorityType.PHENIX_PRIORITY, geneId, geneSymbol, score);
+        super(PriorityType.LEGACY_PHENIX_PRIORITY, geneId, geneSymbol, score);
         this.hpoSemSimScore = semanticSimilarityScore;
         this.negativeLogP = negLogP;
     }

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/PriorityFactory.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/PriorityFactory.java
@@ -45,7 +45,7 @@ public interface PriorityFactory {
 
     OMIMPriority makeOmimPrioritiser();
 
-    PhenixPriority makePhenixPrioritiser();
+    LegacyPhenixPriority makeLegacyPhenixPrioritiser();
 
     PhivePriority makePhivePrioritiser();
 

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/PriorityFactoryImpl.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/PriorityFactoryImpl.java
@@ -80,8 +80,8 @@ public class PriorityFactoryImpl implements PriorityFactory {
         switch (priorityType) {
             case OMIM_PRIORITY:
                 return makeOmimPrioritiser();
-            case PHENIX_PRIORITY:
-                return makePhenixPrioritiser();
+            case LEGACY_PHENIX_PRIORITY:
+                return makeLegacyPhenixPrioritiser();
             case HIPHIVE_PRIORITY:
                 HiPhiveOptions hiPhiveOptions = HiPhiveOptions.builder()
                         .diseaseId(diseaseId)
@@ -116,9 +116,9 @@ public class PriorityFactoryImpl implements PriorityFactory {
     }
 
     @Override
-    public PhenixPriority makePhenixPrioritiser() {
+    public LegacyPhenixPriority makeLegacyPhenixPrioritiser() {
         boolean symmetric = false;
-        return new PhenixPriority(phenixDataDirectory.toString(), symmetric);
+        return new LegacyPhenixPriority(phenixDataDirectory.toString(), symmetric);
     }
 
     @Override

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/PriorityType.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/prioritisers/PriorityType.java
@@ -30,8 +30,8 @@ public enum PriorityType {
     HIPHIVE_PRIORITY,
     //Prioritises against PPI-RandomWalk-proximity A.K.A "GeneWanderer"
     EXOMEWALKER_PRIORITY,
-    //Prioritises against human phenotypes A.K.A. "HPO Phenomizer prioritizer"
-    PHENIX_PRIORITY,
+    //Prioritises against human phenotypes A.K.A. "Legacy HPO Phenomizer prioritizer"
+    LEGACY_PHENIX_PRIORITY,
     //Prioritises against human-mouse phenotype similarities
     PHIVE_PRIORITY,
     //Prioritises against OMIM data

--- a/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/analysis/AnalysisBuilderTest.java
+++ b/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/analysis/AnalysisBuilderTest.java
@@ -369,7 +369,7 @@ public class AnalysisBuilderTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testAddPhenixPrioritiserThrowsExceptionWhenNoHpoIdsDefined() {
-        Prioritiser prioritiser = priorityFactory.makePhenixPrioritiser();
+        Prioritiser prioritiser = priorityFactory.makeLegacyPhenixPrioritiser();
 
         analysisBuilder.addPhenixPrioritiser();
 
@@ -378,7 +378,7 @@ public class AnalysisBuilderTest {
 
     @Test
     public void testCanSpecifyPhenixPrioritiser() {
-        Prioritiser prioritiser = priorityFactory.makePhenixPrioritiser();
+        Prioritiser prioritiser = priorityFactory.makeLegacyPhenixPrioritiser();
 
         analysisBuilder.hpoIds(hpoIds)
                 .addPhenixPrioritiser();

--- a/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/analysis/AnalysisParserTest.java
+++ b/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/analysis/AnalysisParserTest.java
@@ -330,7 +330,7 @@ public class AnalysisParserTest {
     @Test
     public void testParseAnalysisStep_PhenixPrioritiser() {
         Analysis analysis = instance.parseAnalysis(addStepToAnalysis("phenixPrioritiser: {}"));
-        analysisSteps.add(priorityFactory.makePhenixPrioritiser());
+        analysisSteps.add(priorityFactory.makeLegacyPhenixPrioritiser());
         assertThat(analysis.getAnalysisSteps(), equalTo(analysisSteps));
     }
 

--- a/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/prioritisers/NoneTypePriorityFactoryStub.java
+++ b/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/prioritisers/NoneTypePriorityFactoryStub.java
@@ -51,8 +51,8 @@ public class NoneTypePriorityFactoryStub implements PriorityFactory {
     }
 
     @Override
-    public PhenixPriority makePhenixPrioritiser() {
-        return new PhenixPriority(true);
+    public LegacyPhenixPriority makeLegacyPhenixPrioritiser() {
+        return new LegacyPhenixPriority(true);
     }
 
     @Override

--- a/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/prioritisers/PriorityFactoryImplTest.java
+++ b/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/prioritisers/PriorityFactoryImplTest.java
@@ -129,8 +129,8 @@ public class PriorityFactoryImplTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testmakePrioritiserForPhenixPriorityThrowsRuntimeExceptionDueToMissingPhenixData() {
-        PriorityType type = PriorityType.PHENIX_PRIORITY;
+    public void testmakePrioritiserForLegacyPhenixPriorityThrowsRuntimeExceptionDueToMissingPhenixData() {
+        PriorityType type = PriorityType.LEGACY_PHENIX_PRIORITY;
         PrioritiserSettings settings = buildValidSettingsWithPrioritiser(type);
 
         Prioritiser prioritiser = instance.makePrioritiser(settings);

--- a/exomiser-rest-prioritiser/src/main/java/org/monarchinitiative/exomiser/rest/prioritiser/api/PrioritiserController.java
+++ b/exomiser-rest-prioritiser/src/main/java/org/monarchinitiative/exomiser/rest/prioritiser/api/PrioritiserController.java
@@ -108,7 +108,7 @@ public class PrioritiserController {
     private Prioritiser parsePrioritser(String prioritiserName, String prioritiserParams) {
         switch(prioritiserName) {
             case "phenix":
-                return priorityFactory.makePhenixPrioritiser();
+                return priorityFactory.makeLegacyPhenixPrioritiser();
             case "phive":
                 return priorityFactory.makePhivePrioritiser();
             case "hiphive":


### PR DESCRIPTION
OK, so here it comes. I think the following makes sense:

- [x] Rebrand the old implementation as "Legacy Phenix" as Phenix 2 is already taken by the work of @drseb  and @visze with the Exomiser.
- [ ] Add a newly implemented "Phenix" Priotizer using OntoLib.

Outside the scope of this PR:

- Removing Legacy Phenix after making sure that there is no regression in terms of performance.