### PR TITLE
Phenix2

### DIFF
--- a/exomiser-cli/pom.xml
+++ b/exomiser-cli/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.monarchinitiative</groupId>
             <artifactId>exomiser-spring-boot-starter</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/exomiser-core/pom.xml
+++ b/exomiser-core/pom.xml
@@ -45,7 +45,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--Guava 0.19 is required by Jannovar-->
         <dependency>
             <groupId>org.jblas</groupId>
             <artifactId>jblas</artifactId>

--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/analysis/AnalysisBuilder.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/analysis/AnalysisBuilder.java
@@ -227,6 +227,11 @@ public class AnalysisBuilder {
         addPrioritiserStepIfHpoIdsNotEmpty(priorityFactory.makeHiPhivePrioritiser(hiPhiveOptions));
         return this;
     }
+    
+    public AnalysisBuilder addBOQAPrioritiser() {
+        addPrioritiserStepIfHpoIdsNotEmpty(priorityFactory.makeBOQAPrioritiser());
+        return this;
+    }
 
     public AnalysisBuilder addPhenixPrioritiser() {
         addPrioritiserStepIfHpoIdsNotEmpty(priorityFactory.makePhenixPrioritiser());

--- a/exomiser-db/pom.xml
+++ b/exomiser-db/pom.xml
@@ -65,12 +65,12 @@
         <dependency>
             <groupId>org.monarchinitiative</groupId>
             <artifactId>exomiser-core</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>${spring-boot.version}</version>
+            <!--<version>${spring-boot.version}</version>-->
         </dependency>
         <!-- Database dependencies-->
         <dependency>

--- a/exomiser-spring-boot-autoconfigure/pom.xml
+++ b/exomiser-spring-boot-autoconfigure/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.monarchinitiative</groupId>
             <artifactId>exomiser-core</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/exomiser-spring-boot-test/pom.xml
+++ b/exomiser-spring-boot-test/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.monarchinitiative</groupId>
             <artifactId>exomiser-core</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.organization>The Monarch Initiative</project.organization>
         <sonar.language>java</sonar.language>
-        <jannovar.version>0.21</jannovar.version>
-        <guava.version>21.0</guava.version>
-        <spring-boot.version>1.4.1.RELEASE</spring-boot.version>
+        <jannovar.version>0.23</jannovar.version>
+        <guava.version>22.0</guava.version>
+        <spring-boot.version>1.5.6.RELEASE</spring-boot.version>
     </properties>
  
     <repositories>
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>io.spring.platform</groupId>
                 <artifactId>platform-bom</artifactId>
-                <version>Athens-RELEASE</version>
+                <version>Brussels-SR4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
- cherry pick jannovar0.23 commit
- add default BOQA runner to AnalysisBuilder
- fixing bug in BOQAPriority: Exeption was raised and Exomiser was terminated if an HPO ID string was not available. No it is handled similar to PHENIX. Term was removed and and a warning was logged.
