### PR TITLE
Add a gene symbol anchor to the result html page

### DIFF
--- a/exomiser-core/src/main/resources/templates/results.html
+++ b/exomiser-core/src/main/resources/templates/results.html
@@ -149,7 +149,7 @@
         </div>
     </div>
     <div class="panel panel-default" th:each="gene, iterStat: ${genes}">
-        <div class="panel-heading">
+        <div th:id="${gene.getGeneIdentifier().getGeneSymbol()}" class="panel-heading">
             <div class="row">
                 <div class="col-sm-3">
                     <h4 th:switch="${transcriptDb}" th:with="geneIdentifier=${gene.getGeneIdentifier()}">


### PR DESCRIPTION
This allows user navigate to the section with the gene symbol in the result page programmatically.