### PR TITLE
new docker distroless image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <protobuf.version>3.21.12</protobuf.version>
         <spring-boot.version>2.7.7</spring-boot.version>
         <docker.base.image>
-            gcr.io/distroless/java17-debian11@sha256:d5a7bb2b1bcd09d9b7ba7f7b13df39cbb2ab2ff73a0ab834a5769e59229af2f8
+            gcr.io/distroless/java17-debian11@sha256:7c035b36d792b1a067d7a9eb86b444b9c42ba8e885b6d537860437dc30df0306
         </docker.base.image>
         <docker.registry>docker.io</docker.registry>
         <docker.repository>exomiser</docker.repository>


### PR DESCRIPTION
The old docker-distroless image had some compatibility issues.

During an analysis it would report an error during creation of a default output directory.
```
2023-03-29 11:07:49.196 ERROR 1 --- [           main] o.m.exomiser.cli.config.MainConfig       : Unable to create default output directory for results /app/classes/results

java.nio.file.AccessDeniedException: /app/classes/results
```

Also, sometimes I had parsing errors like:
```
Caused by: htsjdk.tribble.TribbleException$MalformedFeatureFile: Unable to parse header with error: /home/nonroot/exomiser/Pfeiffer.vcf.gz, for input source: file:///home/nonroot/exomiser/Pfeiffer.vcf.gz

```

The new distoless image does not create those errors.