### PR TITLE
Fix logging configuration for HikariCP

### DIFF
--- a/exomiser-cli/src/main/resources/application.properties
+++ b/exomiser-cli/src/main/resources/application.properties
@@ -81,4 +81,4 @@ exomiser.phenotype.data-version=${phenotype.data.version}
 ### logging ###
 # Logging is highly configurable - see https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.logging.file-output
 #logging.file.name=logs/exomiser.log
-logging.level.com.zaxxer.hikari=ERROR ${java.version}
+logging.level.com.zaxxer.hikari=ERROR


### PR DESCRIPTION
It looks like somehow an extra `${java.version}` found its way in here. Maybe an editor or commit error? Running with this application.properties without removing this gives me an error related to the resulting string not being one of the logging error types.