### PR TITLE
fix: SvAnna scores now calculated for >1kb non-symbolic SV insertions

### DIFF
--- a/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/model/VariantEvaluation.java
+++ b/exomiser-core/src/main/java/org/monarchinitiative/exomiser/core/model/VariantEvaluation.java
@@ -409,7 +409,7 @@ public class VariantEvaluation extends AbstractVariant implements Comparable<Var
 
     private float variantEffectScore() {
         float variantEffectScore = VariantEffectPathogenicityScore.pathogenicityScoreOf(variantEffect);
-        if (this.isSymbolic()) {
+        if (this.isSymbolic() || Math.abs(this.changeLength()) >= 1000) {
             // SvAnna scoring https://genomemedicine.biomedcentral.com/articles/10.1186/s13073-022-01046-6/tables/1
             //                                     |             element contains v
             // class | v contains t | v overlaps t | Coding or splice | UTR   | Intronic | Promoter

--- a/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/model/VariantEvaluationTest.java
+++ b/exomiser-core/src/test/java/org/monarchinitiative/exomiser/core/model/VariantEvaluationTest.java
@@ -473,6 +473,23 @@ public class VariantEvaluationTest {
         assertThat(sv.pathogenicityScore(), equalTo(expected));
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "CODING_SEQUENCE_VARIANT, 0.2",
+            "SPLICE_REGION_VARIANT, 0.9",
+            "CODING_TRANSCRIPT_VARIANT, 0.0",
+            "SEQUENCE_VARIANT, 0.0",
+    })
+    void testLargeNonSymbolicInsertionScores(VariantEffect variantEffect, float expected) {
+        // Non-symbolic insertions >= 1000bp are routed to the structural variant annotator and should
+        // receive SvAnna-based scoring, not the default SEQUENCE_VARIANT score of 0.0
+        String longAlt = "A".repeat(1001);
+        VariantEvaluation sv = newBuilder(2, 1, 1, "A", longAlt, 1000)
+                .variantEffect(variantEffect)
+                .build();
+        assertThat(sv.pathogenicityScore(), equalTo(expected));
+    }
+
     @Test
     public void testFailedFilterTypesDontContainPassedFilterTypes() {
         Set<FilterType> expectedFilters = EnumSet.of(FAIL_FREQUENCY_RESULT.filterType());


### PR DESCRIPTION
### Summary
Variant scores were not calculated for non-symbolic insertions larger than 1000 bases.

### Issues
* closes #633 
* originally noticed in https://github.com/monarch-initiative/pheval.exomiser/issues/103 